### PR TITLE
修复卡片点击无响应问题

### DIFF
--- a/src/components/screens/CombatScreen.js
+++ b/src/components/screens/CombatScreen.js
@@ -29,7 +29,7 @@ const CombatScreen = () => {
   // 處理卡牌點擊
   const handleCardPlay = (card) => {
     // 如果不是玩家回合或能量不足，則不能打出卡牌
-    if (!isPlayerTurn || energy < card.value) return;
+    if (!isPlayerTurn || energy < card.energy) return;
     
     // 確定目標 (對於攻擊牌是敵人，對於技能牌是自己)
     const targetId = card.target === 'enemy' ? currentEnemy.id : player.id;


### PR DESCRIPTION
## 问题描述
在游戏中点击卡片没有反应

## 解决方案
修复了CombatScreen.js中handleCardPlay函数的能量判断逻辑，将`card.value`改为`card.energy`，与GameContext.js中的playCard函数保持一致。

## 变更详情
- 在CombatScreen.js中handleCardPlay函数的条件判断从`energy < card.value`改为`energy < card.energy`
- 这样确保了能量判断的一致性，修复了点击卡片无反应的问题

## 测试
请测试是否可以正常点击卡片并使用。